### PR TITLE
Move Voting Support under How To Claim Your Vote #88

### DIFF
--- a/index.html
+++ b/index.html
@@ -521,7 +521,7 @@
                         </ul>
                     </div>
                 </div>
-                <div class="bannerbox" id="blank">                   
+                <div>                   
                 </div>
                 <div class="bannerbox" id="countdown">
                     <h3 class="bannerbox__title">2016 Election Countdown Clock</h3>

--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
                                 <label for="RiderWillBeSafe">
                                     <input type="checkbox" id="RiderWillBeSafe" name="RiderWillBeSafe" required /> I understand that Carpool Vote provides introductions between riders and volunteer drivers who have signed up on the platform. I understand that anybody can sign up to drive and Carpool Vote is unable to perform any background checks on people who use the platform. As with any other environment where I meet new people, I will take steps to keep myself and my possessions safe and accept that Carpool Vote cannot be responsible if anything goes wrong.
                                 </label>
-								<div class="help-block with-errors"></div>
+                                <div class="help-block with-errors"></div>
                             </div>
                             <div class="form-group checkbox">
                                 <label for="RiderWillNotTalkPolitics">
@@ -397,7 +397,7 @@
                                 <label for="legalFive">
                                     <input type="checkbox" id="legalFive" name="DriverWillNotTalkPolitics" required /> I understand that this service is open to any driver or rider - no matter what their personal background or beliefs. To help make sure that both the driver and I feel comfortable and safe, I promise that I will not discuss politics during the journey.
                                 </label>
-								<div class="help-block with-errors"></div>
+                                <div class="help-block with-errors"></div>
                             </div>
                             <div class="form-group checkbox">
                                 <label for="inTouchDriver">
@@ -427,9 +427,9 @@
                         <p>Under the new rules, voters in several states face new barriers to getting to the polls. Some of the obstacles that Carpool Vote aims to reduce include:</p>
                         <ul>
                             <li>Polling stations face closure in lower-income communities of color,</li>
-                        	<li>Would-be voters have to travel out of town to get a photo ID to register,</li>
-                        	<li>The periods available to register and vote become shorter, and</li>
-                        	<li>Requesting an absentee ballot or voting by mail can be difficult in many states.</li>
+                            <li>Would-be voters have to travel out of town to get a photo ID to register,</li>
+                            <li>The periods available to register and vote become shorter, and</li>
+                            <li>Requesting an absentee ballot or voting by mail can be difficult in many states.</li>
                         </ul>
                         <p>These rules - along with others introduced since the change - affect everybody but especially people of color, people with disabilities, young people, elderly people, and women.</p>
                     </div>
@@ -451,18 +451,6 @@
                             <li><a href="https://www.rockthevote.com/get-informed/elections/voter-id-requirements/state/" target="_rtv">Voter requirements</a></li>
                             <li><a href="https://www.rockthevote.com/get-informed/elections/find-your-polling-place/" target="_rtv">Find where to vote</a></li>
                             <li><a href="https://www.rockthevote.com/get-informed/elections/" target="_rtv">About elections</a></li>
-                        </ul>
-                    </div>
-                </div>
-                <div class="bannerbox" id="righttovote">
-                    <h3 class="bannerbox__title">Voting support</h3>
-                    <div class="bannerbox__content">
-                        <a href="http://www.866ourvote.org/"><img class="align-right" src="res/img/election-protection.png" /></a>
-                        <p>The <a href="http://www.866ourvote.org/">Election Protection Coalition</a> works around the clock to advance and defend your right to vote.</p>
-                        <p>Report voting problems, and get voting relating info for your state.</p>
-                        <ul>
-                            <li>Visit <a href="http://www.866ourvote.org/">866ourvote.org</a></li>
-                            <li>Call <a href="tel:8666878683">866-OUR-VOTE</a></li>
                         </ul>
                     </div>
                 </div>
@@ -488,7 +476,6 @@
                                 <input type="email" class="form-input" id="helpEmail" placeholder="Email" name="Email" required>
                                 <div class="help-block with-errors"></div>
                             </div>
-
                             <div class="form-group checkbox checkbox--multi">
                                 <p><b>I can:</b></p>
                                 <label>
@@ -521,6 +508,20 @@
                             </div>
                         </form>
                     </div>
+                </div>
+                <div class="bannerbox" id="righttovote">
+                    <h3 class="bannerbox__title">Voting support</h3>
+                    <div class="bannerbox__content">
+                        <a href="http://www.866ourvote.org/"><img class="align-right" src="res/img/election-protection.png" /></a>
+                        <p>The <a href="http://www.866ourvote.org/">Election Protection Coalition</a> works around the clock to advance and defend your right to vote.</p>
+                        <p>Report voting problems, and get voting relating info for your state.</p>
+                        <ul>
+                            <li>Visit <a href="http://www.866ourvote.org/">866ourvote.org</a></li>
+                            <li>Call <a href="tel:8666878683">866-OUR-VOTE</a></li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="bannerbox" id="blank">                   
                 </div>
                 <div class="bannerbox" id="countdown">
                     <h3 class="bannerbox__title">2016 Election Countdown Clock</h3>


### PR DESCRIPTION
Re-ordered div so that "Voting Support" shows up under "How To Claim Your Vote". Added a blank div to force "Can I Help Some Other Way?" to the left side of the page, however, this blank div sometimes shows up underneath "Can I Help Some Other Way?" and I am unsure how to remedy that. Without the blank div, the countdown clock shows up on the left side, leaving a lot of empty space in the right column.