### PR TITLE
display uuid on thanks page and provide valid link to self service

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
 
         <div id="forms" class="forms wrapper offset-top">
             <form id="need-ride" name="needRide" action="https://api.carpoolvote.com/live/rider" method="post" class="ride-form" role="form" aria-hidden="true">
-                <input type="hidden" name="_redirect" class="redirect" value="http://carpoolvote.com/thanks-rider/?type=rider" />
+                <input type="hidden" name="_redirect" class="redirect" value="http://carpoolvote.com/thanks-rider/" />
                 <div class="bannerbox">
                     <h2 class="bannerbox__title">I need a ride</h2>
                     <div class="bannerbox__content">
@@ -285,7 +285,7 @@
             </form>
 
             <form id="offer-ride" name="offerRide" action="https://api.carpoolvote.com/live/driver" method="post" class="ride-form" role="form" aria-hidden="true">
-                <input type="hidden" name="_redirect" class="redirect" value="http://carpoolvote.com/thanks-driver/?type=driver" />
+                <input type="hidden" name="_redirect" class="redirect" value="http://carpoolvote.com/thanks-driver/" />
                 <div class="bannerbox">
                     <h2 class="bannerbox__title">I can offer a ride</h2>
                     <div class="bannerbox__content">

--- a/scripts/querystring-driver.js
+++ b/scripts/querystring-driver.js
@@ -1,0 +1,54 @@
+// TinyQueryString - A really tiny URL query string utility
+// github.com/richardwestenra/tiny-query-string
+!function(t,e){"function"==typeof define&&define.amd?define(["tinyQuery"],e):"object"==typeof module&&module.exports?module.exports=e():t.tinyQuery=e()}(this,function(){"use strict";var t=function(t){return RegExp("[?&]("+t+")=?([^&#]*)","i")},e=function(t){return"string"!=typeof t?"undefined"!=typeof window?window.location.search:"":t};return{get:function(t,e){return"object"==typeof t?this.getMany.apply(this,arguments):t&&e!==!1?this.getOne.apply(this,arguments):this.getAll.apply(this,arguments)},getOne:function(n,r){var i=e(r).match(t(n));return i?i[2]?decodeURIComponent(i[2]):!0:!1},getMany:function(t,n){return t.reduce(function(t,r){return t[r]=this.getOne(r,e(n)),t}.bind(this),{})},getAll:function(t){if(t=e(t).match(/\?(.+)/)){var n=t[1].split("&").map(function(t){return t.split("=")[0].toLowerCase()});return this.getMany.call(this,n,t[0])}return{}},set:function(t){return"object"==typeof t?this.setMany.apply(this,arguments):this.setOne.apply(this,arguments)},setOne:function(n,r,i){i=e(i);var u=t(n),o=u.exec(i);return!r||"string"!=typeof r&&"number"!=typeof r||(n=n+"="+encodeURIComponent(r)),!i.length||i.indexOf("?")<0?(i||"")+"?"+n:o?i.replace(u,o[0].charAt(0)+n):i+"&"+n},setMany:function(t,n){return Array.isArray(t)?t.reduce(function(t,e){return this.setOne(e,!1,t)}.bind(this),e(n)):Object.keys(t).reduce(function(e,n){return this.setOne(n,t[n],e)}.bind(this),e(n))},remove:function(t,e){return"object"==typeof t?this.removeMany.apply(this,arguments):t&&e!==!1?this.removeOne.apply(this,arguments):this.removeAll.apply(this,arguments)},removeOne:function(t,n){if(n=e(n).match(/([^\?]*)(\?*.*)/)){if(n[2].length){var r=Object.keys(this.getAll(n[2])).filter(function(e){return e!==t});return this.setMany(r,n[1])}return n[1]}return!1},removeMany:function(t,n){return t.reduce(function(t,e){return this.removeOne(e,t)}.bind(this),e(n))},removeAll:function(t){return e(t).split("?")[0]}}});
+
+
+// Update Query String properties on each page
+
+(function(){
+    function gid(id) {
+      return document.getElementById(id);
+    }
+    function qsa(s) {
+      return document.querySelectorAll(s);
+    }
+    function forEach(array, callback, scope) {
+      for (var i = 0; i < array.length; i++) {
+        callback.call(scope || array[i], i, array[i]);
+      }
+    }
+
+    var qs = tinyQuery.getAll();
+
+    if (qs.souls2thepolls) {
+        var intro = gid('intro');
+        if (intro) {
+          intro.classList.add('s2tp');
+        }
+
+        var logo = gid('logo');
+        logo.setAttribute('src', '/images/logo-souls2thepolls.png');
+        logo.setAttribute('width', 661);
+        logo.setAttribute('height', 300);
+
+        forEach(qsa('a[href^="/"]'), function() {
+          this.href = tinyQuery.set('souls2thepolls', false, this.href);
+        });
+
+        forEach(qsa('.twitter-mention-button'), function() {
+          var url = this.getAttribute('data-url');
+          this.setAttribute('data-url', tinyQuery.set('souls2thepolls', false, url));
+        });
+    }
+
+    if (qs.uuid) {
+        forEach(qsa('.uuid'), function() {
+            this.textContent = qs.uuid;
+        });
+
+        forEach(qsa('.self-service-url'), function() {
+            // this.href = tinyQuery.set(qs, this.href);
+            this.href += "?UUID_driver=" + qs.uuid;
+        });
+    }
+})();

--- a/scripts/querystring-rider.js
+++ b/scripts/querystring-rider.js
@@ -1,0 +1,54 @@
+// TinyQueryString - A really tiny URL query string utility
+// github.com/richardwestenra/tiny-query-string
+!function(t,e){"function"==typeof define&&define.amd?define(["tinyQuery"],e):"object"==typeof module&&module.exports?module.exports=e():t.tinyQuery=e()}(this,function(){"use strict";var t=function(t){return RegExp("[?&]("+t+")=?([^&#]*)","i")},e=function(t){return"string"!=typeof t?"undefined"!=typeof window?window.location.search:"":t};return{get:function(t,e){return"object"==typeof t?this.getMany.apply(this,arguments):t&&e!==!1?this.getOne.apply(this,arguments):this.getAll.apply(this,arguments)},getOne:function(n,r){var i=e(r).match(t(n));return i?i[2]?decodeURIComponent(i[2]):!0:!1},getMany:function(t,n){return t.reduce(function(t,r){return t[r]=this.getOne(r,e(n)),t}.bind(this),{})},getAll:function(t){if(t=e(t).match(/\?(.+)/)){var n=t[1].split("&").map(function(t){return t.split("=")[0].toLowerCase()});return this.getMany.call(this,n,t[0])}return{}},set:function(t){return"object"==typeof t?this.setMany.apply(this,arguments):this.setOne.apply(this,arguments)},setOne:function(n,r,i){i=e(i);var u=t(n),o=u.exec(i);return!r||"string"!=typeof r&&"number"!=typeof r||(n=n+"="+encodeURIComponent(r)),!i.length||i.indexOf("?")<0?(i||"")+"?"+n:o?i.replace(u,o[0].charAt(0)+n):i+"&"+n},setMany:function(t,n){return Array.isArray(t)?t.reduce(function(t,e){return this.setOne(e,!1,t)}.bind(this),e(n)):Object.keys(t).reduce(function(e,n){return this.setOne(n,t[n],e)}.bind(this),e(n))},remove:function(t,e){return"object"==typeof t?this.removeMany.apply(this,arguments):t&&e!==!1?this.removeOne.apply(this,arguments):this.removeAll.apply(this,arguments)},removeOne:function(t,n){if(n=e(n).match(/([^\?]*)(\?*.*)/)){if(n[2].length){var r=Object.keys(this.getAll(n[2])).filter(function(e){return e!==t});return this.setMany(r,n[1])}return n[1]}return!1},removeMany:function(t,n){return t.reduce(function(t,e){return this.removeOne(e,t)}.bind(this),e(n))},removeAll:function(t){return e(t).split("?")[0]}}});
+
+
+// Update Query String properties on each page
+
+(function(){
+    function gid(id) {
+      return document.getElementById(id);
+    }
+    function qsa(s) {
+      return document.querySelectorAll(s);
+    }
+    function forEach(array, callback, scope) {
+      for (var i = 0; i < array.length; i++) {
+        callback.call(scope || array[i], i, array[i]);
+      }
+    }
+
+    var qs = tinyQuery.getAll();
+
+    if (qs.souls2thepolls) {
+        var intro = gid('intro');
+        if (intro) {
+          intro.classList.add('s2tp');
+        }
+
+        var logo = gid('logo');
+        logo.setAttribute('src', '/images/logo-souls2thepolls.png');
+        logo.setAttribute('width', 661);
+        logo.setAttribute('height', 300);
+
+        forEach(qsa('a[href^="/"]'), function() {
+          this.href = tinyQuery.set('souls2thepolls', false, this.href);
+        });
+
+        forEach(qsa('.twitter-mention-button'), function() {
+          var url = this.getAttribute('data-url');
+          this.setAttribute('data-url', tinyQuery.set('souls2thepolls', false, url));
+        });
+    }
+
+    if (qs.uuid) {
+        forEach(qsa('.uuid'), function() {
+            this.textContent = qs.uuid;
+        });
+
+        forEach(qsa('.self-service-url'), function() {
+            // this.href = tinyQuery.set(qs, this.href);
+            this.href += "?UUID_rider=" + qs.uuid;
+        });
+    }
+})();

--- a/thanks-driver/index.html
+++ b/thanks-driver/index.html
@@ -162,6 +162,6 @@
         ga('send', 'pageview');
     </script>
 
-    <script src="../scripts/querystring.js"></script>
+    <script src="../scripts/querystring-driver.js"></script>
 </body>
 </html>

--- a/thanks-rider/index.html
+++ b/thanks-rider/index.html
@@ -161,6 +161,6 @@
         ga('send', 'pageview');
     </script>
 
-    <script src="../scripts/querystring.js"></script>
+    <script src="../scripts/querystring-rider.js"></script>
 </body>
 </html>


### PR DESCRIPTION
@richardwestenra this PR enables the thanks page to both display the uuid on the thanks pages (not currently happening) and to provide a valid link to the self service page.

This PR corrects the redirection to the thanks pages from the main page. The existing redirect does not provide a valid url (due to the way the node app has always worked). The href for the self service page has been changed due to the revised url received.

All that is changed in the added querystring files is the href line. This is your code, so it seemed best to get something working and leave you to refactor later as you think is best
