### PR TITLE
reversed order of countdown and support boxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -431,6 +431,26 @@
                         </ul>
                     </div>
                 </div>
+                <div class="bannerbox" id="countdown">
+                    <h2 class="bannerbox__title">2016 Election Countdown Clock</h2>
+                    <div class="bannerbox__content">
+                        <iframe src="http://www.270towin.com/2016-countdown-clock/widget300x200.php" width="300" height="200" border="0" frameBorder="0" style="max-width:100%">
+                            Browser not supported. Visit <a href="http://www.270towin.com/">www.270towin.com</a>
+                        </iframe>
+                    </div>
+                </div>
+                <div class="bannerbox" id="righttovote">
+                    <h2 class="bannerbox__title">Voting support</h2>
+                    <div class="bannerbox__content">
+                        <a href="http://www.866ourvote.org/"><img class="align-right" src="images/election-protection.png" alt="Election Protection logo" width=161 height=47 /></a>
+                        <p>The <a href="http://www.866ourvote.org/">Election Protection Coalition</a> works around the clock to advance and defend your right to vote.</p>
+                        <p>Report voting problems, and get voting related info for your state.</p>
+                        <ul>
+                            <li>Visit <a href="http://www.866ourvote.org/">866ourvote.org</a></li>
+                            <li>Call <a href="tel:8666878683">866-OUR-VOTE</a></li>
+                        </ul>
+                    </div>
+                </div>
                 <div class="bannerbox" id="support">
                     <h2 class="bannerbox__title">Can I help some other way?</h2>
                     <div class="bannerbox__content">
@@ -481,26 +501,6 @@
                                 <button type="submit" class="button button--large" id="offerHelpSubmit">Offer help</button>
                             </div>
                         </form>
-                    </div>
-                </div>
-                <div class="bannerbox" id="righttovote">
-                    <h2 class="bannerbox__title">Voting support</h2>
-                    <div class="bannerbox__content">
-                        <a href="http://www.866ourvote.org/"><img class="align-right" src="images/election-protection.png" alt="Election Protection logo" width=161 height=47 /></a>
-                        <p>The <a href="http://www.866ourvote.org/">Election Protection Coalition</a> works around the clock to advance and defend your right to vote.</p>
-                        <p>Report voting problems, and get voting related info for your state.</p>
-                        <ul>
-                            <li>Visit <a href="http://www.866ourvote.org/">866ourvote.org</a></li>
-                            <li>Call <a href="tel:8666878683">866-OUR-VOTE</a></li>
-                        </ul>
-                    </div>
-                </div>
-                <div class="bannerbox" id="countdown">
-                    <h2 class="bannerbox__title">2016 Election Countdown Clock</h2>
-                    <div class="bannerbox__content">
-                        <iframe src="http://www.270towin.com/2016-countdown-clock/widget300x200.php" width="300" height="200" border="0" frameBorder="0" style="max-width:100%">
-                            Browser not supported. Visit <a href="http://www.270towin.com/">www.270towin.com</a>
-                        </iframe>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Fixes #192

I didn't mean to get rid of my last PR. Sorry! Wanting the map at the top makes perfect sense @sasjkia :+1: 

So this is a simple swap of the countdown and support boxes - just like the screenshot you put in my previous PR, @richardwestenra, except I left the 'how to claim' and 'right to vote' boxes in the original order.