### PR TITLE
FAQ typo - fixes #232

### DIFF
--- a/faq/index.html
+++ b/faq/index.html
@@ -141,21 +141,21 @@
                         <li class="faq-question"><a href="#faq10">I have received a proposed rider match. Does that mean I need to drive them?</a></li>
                         <li class="faq-question"><a href="#faq11">What happens if I cancel a confirmed match?</a></li>
                         <li class="faq-question"><a href="#faq12">What happens if I cancel my ride offer or request?</a></li>
-                        <li class="faq-question"><a href="#faq13">I want to drive where I'm needed the most. How can I find out where and when riders need me?</a></li>
-                        <li class="faq-question"><a href="#faq14">One of the riders on the map is within my driving radius. Why have we not been matched?</a></li>
-                        <li class="faq-question"><a href="#faq15">I want to drive where I'm needed the most. How can I find out where and when riders need me?</a></li>
-                        <li class="faq-question"><a href="#faq16">One of the riders on the map is within my driving radius. Why have we not been matched?</a></li>
-                        <li class="faq-question"><a href="#faq17">I am receiving ride requests outside of the radius or time that I specified</a></li>
-                        <li class="faq-question"><a href="#faq18">My organization is already arranging rides to the polls. How can we work together?</a></li>
-                        <li class="faq-question"><a href="#faq19">My organization works with voters who need your service but can't access the platform. How can we work together?</a></li>
-                        <li class="faq-question"><a href="#faq20">Does your platform meet Web Content Accessibility Guidelines?</a></li>
-                        <li class="faq-question"><a href="#faq21">Do you do background checks on drivers?</a></li>
-                        <li class="faq-question"><a href="#faq22">Can you guarantee that I'll be matched with a driver / rider?</a></li>
-                        <li class="faq-question"><a href="#faq23">Who runs the Carpool Vote?</a></li>
-                        <li class="faq-question"><a href="#faq24">Are you affiliated with any political party?</a></li>
-                        <li class="faq-question"><a href="#faq25">How do you make money?</a></li>
-                        <li class="faq-question"><a href="#faq26">Do you have an app?</a></li>
-                        <li class="faq-question"><a href="#faq27">I have received a proposed match notification, why won't the system let me accept it?</a></li>
+                        <li class="faq-question"><a href="#faq13">I have received a proposed match notification, why won't the system let me accept it?</a></li>
+                        <li class="faq-question"><a href="#faq14">I want to drive where I'm needed the most. How can I find out where and when riders need me?</a></li>
+                        <li class="faq-question"><a href="#faq15">One of the riders on the map is within my driving radius. Why have we not been matched?</a></li>
+                        <li class="faq-question"><a href="#faq16">I want to drive where I'm needed the most. How can I find out where and when riders need me?</a></li>
+                        <li class="faq-question"><a href="#faq17">One of the riders on the map is within my driving radius. Why have we not been matched?</a></li>
+                        <li class="faq-question"><a href="#faq18">I am receiving ride requests outside of the radius or time that I specified</a></li>
+                        <li class="faq-question"><a href="#faq19">My organization is already arranging rides to the polls. How can we work together?</a></li>
+                        <li class="faq-question"><a href="#faq20">My organization works with voters who need your service but can't access the platform. How can we work together?</a></li>
+                        <li class="faq-question"><a href="#faq21">Does your platform meet Web Content Accessibility Guidelines?</a></li>
+                        <li class="faq-question"><a href="#faq22">Do you do background checks on drivers?</a></li>
+                        <li class="faq-question"><a href="#faq23">Can you guarantee that I'll be matched with a driver / rider?</a></li>
+                        <li class="faq-question"><a href="#faq24">Who runs the Carpool Vote?</a></li>
+                        <li class="faq-question"><a href="#faq25">Are you affiliated with any political party?</a></li>
+                        <li class="faq-question"><a href="#faq26">How do you make money?</a></li>
+                        <li class="faq-question"><a href="#faq27">Do you have an app?</a></li>
                     </ul>
 
                     <h2>Answers</h2>
@@ -245,81 +245,81 @@
                             <p>All of of your confirmed matches will be canceled and you will no longer receive any notifications. Only use this option if you are certain that you no longer want to give a ride to anybody - including your existing matches - or you no longer need a ride.</p>
                         </li>
                         <li id="faq13" class="faq-answer">
-                            <h3>I want to drive where I'm needed the most. How can I find out where and when riders need me?</h3>
-                            <p>We publish a map of unmatched riders and drivers on our home page. You can type in your zip code or neighborhood to find out where there are voters who still need to find a ride. You can find out more about the location by clicking on individual rider icons. Our map does not currently display riders' available dates and times.</p>
+                          <h3>I have received a proposed match notification, why won't the system let me accept it?</h3>
+                          <p>You can accept a match by clicking the "Accept" link in the email notification or by visiting the self-service portal.</p>
+                          <p>If the link doesn't work and you can't see a proposed match in the self-service portal, this is good news! It means that someone else has already accepted the ride request and the voter is on their way to the polls!</p>
+                          <p>You don't need to do anything else. You'll keep receiving match notifications.</p>
                         </li>
                         <li id="faq14" class="faq-answer">
-                            <h3>One of the riders on the map is within my driving radius. Why have we not been matched?</h3>
-                            <p> It is possible that their available dates and / or times do not match with yours. Our map does not currently display riders' available dates and times. If you see an unmatched rider and would like to see if you can help, feel free to sign up again with extra dates / times that you could be available.</p>
-                        </li>
-                        <li id="faq15" class="faq-answer">
                             <h3>I want to drive where I'm needed the most. How can I find out where and when riders need me?</h3>
                             <p>We publish a map of unmatched riders and drivers on our home page. You can type in your zip code or neighborhood to find out where there are voters who still need to find a ride. You can find out more about the location by clicking on individual rider icons. Our map does not currently display riders' available dates and times.</p>
                         </li>
-                        <li id="faq16" class="faq-answer">
+                        <li id="faq15" class="faq-answer">
                             <h3>One of the riders on the map is within my driving radius. Why have we not been matched?</h3>
                             <p> It is possible that their available dates and / or times do not match with yours. Our map does not currently display riders' available dates and times. If you see an unmatched rider and would like to see if you can help, feel free to sign up again with extra dates / times that you could be available.</p>
                         </li>
+                        <li id="faq16" class="faq-answer">
+                            <h3>I want to drive where I'm needed the most. How can I find out where and when riders need me?</h3>
+                            <p>We publish a map of unmatched riders and drivers on our home page. You can type in your zip code or neighborhood to find out where there are voters who still need to find a ride. You can find out more about the location by clicking on individual rider icons. Our map does not currently display riders' available dates and times.</p>
+                        </li>
                         <li id="faq17" class="faq-answer">
+                            <h3>One of the riders on the map is within my driving radius. Why have we not been matched?</h3>
+                            <p> It is possible that their available dates and / or times do not match with yours. Our map does not currently display riders' available dates and times. If you see an unmatched rider and would like to see if you can help, feel free to sign up again with extra dates / times that you could be available.</p>
+                        </li>
+                        <li id="faq18" class="faq-answer">
                             <h3>I am receiving ride requests outside of the radius or time that I specified</h3>
                             <p>We've found that some drivers and riders are happy to be a little flexible with time or place, once they realize that someone needs or can give a ride. Sometimes, we send drivers notifications for matches that are a little out of their date or time range, just in case they can still make it.</p>
                             <p>If you signed up up to or before November 5, the offers you receive may be a little less sensitive to location and you may receive offers for up to 100 miles from where you are.</p>
                             <p>If this is the case, and you would like to receive notifications for rides a closer to the radius that you signed up for, simply pause (NOT cancel) notifications for your current ride offer, then sign up again using the same details. This will preserve any matches you've already accepted, while making new notifications more location-sensitive.
                             </p>
                         </li>
-                        <li id="faq18" class="faq-answer">
+                        <li id="faq19" class="faq-answer">
                             <h3>My organization is already arranging rides to the polls. How can we work together?</h3>
                             <p> We partner with many organizations that have their own get-out-the-vote driving efforts and would like an effective way to match their volunteer drivers with voters who need a ride at a time and place that works for both parties. Many of our partners ask their drivers to sign up to our platform while continuing to run their own local outreach. Drivers can then accept the ride requests to fill extra seats in their vehicle or dates / times that they still have spare.</p>
                             <p>By working together in this way, we create more ways for drivers and riders to find each other and so improve the chances of voters being matched with drivers. We especially welcome drivers validated and sent to us by partner organizations because we'd like to match them with vulnerable riders.</p>
                             <p>If your organization has access to volunteer drivers and would like to use Carpool Vote to complement your get-out-the-vote driving efforts, please contact partner@carpoolvote.com and we can set you up with our system.</p>
                         </li>
-                        <li id="faq19" class="faq-answer">
+                        <li id="faq20" class="faq-answer">
                             <h3>My organization works with voters who need your service but can't access the platform. How can we work together?</h3>
                             <p>Our system is designed to be accessible to all voters – including those who do not use the internet on a regular basis.</p>
                             <p>Many of our partners use the platform to sign up on behalf of voters who have asked them to do so. Each new signup generates a unique reference number, which can be used to access ride request information via our <a href="/self-service/">self-service portal</a></p>
                             <p>If the voter does not have regular internet access, they can elect to receive SMS updates on their ride request status. Once a driver has accepted a match, we will send the driver the contact details for the rider. The rider will then get in touch with the rider.</p>
                             <p>We also have a process in place for partners who expect to sign up large volumes of voters. If this sounds like your organization, please get partner@carpoolvote.com and we can set you up with our system.</p>
                         </li>
-                        <li id="faq20" class="faq-answer">
+                        <li id="faq21" class="faq-answer">
                             <h3>Does your platform meet Web Content Accessibility Guidelines?</h3>
                             <p>We have made every effort to make our platform accessible to people with disabilities. We have tested our site with screen readers a provide a matching service for voters using power chairs. Riders are also able to communicate special accommodation needs via the system. Our site is also fully mobile-optimized and accessible via any device.</p>
                             <p>We are an open source project run entirely by volunteers. Our developers do their best to meet the Web Content Accessibility Guidelines but none work specifically with accessibility as a full-time job. So, there is a chance that some of these standards may not be met. If you would like to flag an accessibility issue with us, please contact <a href="mailto:accessibility@carpoolvote.com">accessibility@carpoolvote.com</a></p>
                         </li>
-                        <li id="faq21" class="faq-answer">
+                        <li id="faq22" class="faq-answer">
                             <h3>Do you do background checks on drivers?</h3>
                             <p>Carpool Vote provides introductions between riders and volunteer drivers who have signed up on the platform. By using the service, you accept that anybody can sign up to drive or get a ride and Carpool Vote is unable to perform any background checks on people who use the platform.</p>
                             <p>As with any other environment where I meet new people, I will take steps to keep myself and my possessions safe and accept that Carpool Vote cannot be responsible if anything goes wrong. Riders who would feel safer to do so can request an extra seat via the signup form, so they can take a companion.</p>
                         </li>
-                        <li id="faq22" class="faq-answer">
+                        <li id="faq23" class="faq-answer">
                             <h3>Can you guarantee that I'll be matched with a driver / rider?</h3>
                             <p>We can only propose a match a rider match to drivers who are a good fit for the time, location, and seating / accessibility needs of the rider. Drivers can then choose to accept a match if it works for them. We are unable to ensure that drivers and riders will meet each other's criteria.</p>
                             <p>We have done our best to test the system and to ensure that it works the way it's supposed to. Our testing has not revealed any issues that could prevent the system from finding potentially suitable matches - provided user details have been entered correctly. At the same time, we have not had the opportunity to test the system at scale.</p>
                             <p>So, we encourage both drivers and riders to use the platform as one way to complement their other  efforts to give or get a ride.</p>
                             <p>We also encourage local people and organizations to help us promote the project. The more people there are who know about our service in the same area, the more likely it is that a voter will be matched with a driver and so be able to claim their vote!</p>
                         </li>
-                        <li id="faq23" class="faq-answer">
+                        <li id="faq24" class="faq-answer">
                             <h3>Who runs the Carpool Vote?</h3>
                             <p>Carpool Vote is an open-source project run entirely by volunteers who believe passionately that democracy is for everybody. Our volunteers are based all over the US and in other parts of the world, and all collaborate to bring different skills to the project.</p>
                         </li>
-                        <li id="faq24" class="faq-answer">
+                        <li id="faq25" class="faq-answer">
                             <h3>Are you affiliated with any political party?</h3>
                             <p>We are nonpartisan. This service is open to any driver or rider - no matter what their political views. You do not have to vote for any political party in exchange for receiving this service. In fact, you do not even have to vote! Our volunteers care passionately about empowering you to do this but the decision is ultimately up to you!</p>
                             <p>To help make sure that both the driver and rider feel comfortable and safe, we ask that you do not discuss politics from when you get in the vehicle to when you have completed the last part of the journey.</p>
                         </li>
-                        <li id="faq25" class="faq-answer">
+                        <li id="faq26" class="faq-answer">
                             <h3>How do you make money?</h3>
                             <p>Carpool Vote is a not-for-profit community. The site is free to use and we do not earn an income from it. Several volunteers have already contributed money to the project from their own pockets. We are currently registered as an LLC because it was not possible to obtain 501(c)(3) status in time for the election but any income we generate is through fundraising and is used to run the project.</p>
                         </li>
-                        <li id="faq26" class="faq-answer">
+                        <li id="faq27" class="faq-answer">
                             <h3>Do you have an app?</h3>
                             <p>We want to make this service accessible to everybody who needs it - including those who do not have regular access to the internet or a smartphone. For this reason, we chose to create a web platform that is fully mobile-optimized – so users can access it on their phones or in the library.</p>
                             <p>Riders can choose receive updates on their request status via SMS, if they don't have regular access to the internet.</p>
-                        </li>
-                        <li id="faq27" class="faq-answer">
-                            <h3>I have received a proposed match notification, why won't the system let me accept it?</h3>
-                            <p>You can accept a match by clicking the "Accept" link in the email notification or by visiting the self-service portal.</p>
-                            <p>If the link doesn't work and you can't see a proposed match in the self-service portal, this is good news! It means that someone else has already accepted the ride request and the voter is on their way to the polls!</p>
-                            <p>You don't need to do anything else. You'll keep receiving match notifications.</p>
                         </li>
                     </ul>
                 </div>

--- a/faq/index.html
+++ b/faq/index.html
@@ -166,7 +166,7 @@
                         </li>
                         <li id="faq2" class="faq-answer">
                             <h3>I need to change the details of my signup. How can I do this?</h3>
-                            <p>Simply click the For drivers, the easiest way to change the details of your signup is to pause (NOT cancel) notifications for your current ride offer or request, then sign up again using the same details.</p>
+                            <p>For drivers, the easiest way to change the details of your signup is to pause (NOT cancel) notifications for your current ride offer or request, then sign up again using the same details.</p>
                             <p>This will preserve any matches you've already accepted, while new notifications will have the updated details. I you do not yet have any confirmed matches, you can also cancel your offer.</p>
                             <p>For riders, the easiest way to change details is to cancel your request. If you do not have internet access, you can also call or SMS 804-239-3389, quoting your reference number, and we'll try do this for you.</p>
                         </li>


### PR DESCRIPTION
- Removed typo: 'Simply click the' at beginning of "I need to change the details of my signup. How can I do this?" text
- reordered to put final question, "I have received a proposed match notification, why won't the system let me accept it?", under "What happens if I cancel my current ride offer of request?"