### PR TITLE
removed ourvote from red banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
     </script>
 
     <header class="header">
-        <p class="support-banner">Call <a href="tel:18666878683">1-866-OURVOTE</a> for voter support. For help using Carpool Vote, call or SMS: <a href="tel:8042393389">804-239-3389</a></p>
+        <p class="support-banner">For help using Carpool Vote, call or SMS: <a href="tel:8042393389">804-239-3389</a></p>
         <nav class="nav wrapper">
             <a href="/" class="logo">
                 <img id="logo" class="logo__img" src="images/logo.png" alt="Carpool Vote" width=709 height=187 />


### PR DESCRIPTION
Please check I've understood this correctly :smile: banner will now read "For help using...". The OurVote section is totally removed from the banner by this PR 

Fixes https://github.com/voteamerica/voteamerica.github.io/issues/236