### PR TITLE
Change api URL on staging automatically

### DIFF
--- a/_includes/api.html
+++ b/_includes/api.html
@@ -1,0 +1,7 @@
+{% comment %}
+	Change the API url to the test value on the test repo
+{% endcomment %}
+{% assign api = site.api %}
+{% if site.github.owner_name == 'richardwestenra' %}
+	{% assign api = 'https://api.carpoolvote.com/test' %}
+{% endif %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -73,7 +73,7 @@
     {% elsif page.selfservice %}
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/1000hz-bootstrap-validator/0.11.5/validator.min.js"></script>
-        <script> var remoteUrl = '{{ site.api }}'; </script>
+        <script> var remoteUrl = '{{ api }}'; </script>
         <script src="{{ baseurl }}scripts/selfservice.js"></script>
     {% endif %}
 
@@ -102,7 +102,7 @@
         <!-- JSON parser to GeoJSON by Casey Thomas -->
         <script src="{{ baseurl }}scripts/geojson.min.js"></script>
         <!-- load the map-->
-        <script> var remoteUrl = '{{ site.api }}'; </script>
+        <script> var remoteUrl = '{{ api }}'; </script>
         <script src="{{ baseurl }}scripts/map.js"></script>
     {% endif %}
 </body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,3 +1,5 @@
+{% include api.html %}
+
 {% include baseurl.html %}
 
 {% include header.html %}

--- a/pages/index.html
+++ b/pages/index.html
@@ -49,7 +49,7 @@ permalink: /
     </div>
 
     <div id="forms" class="forms wrapper offset-top">
-        <form id="need-ride" name="needRide" action="{{ site.api }}/rider" method="post" class="ride-form" aria-hidden="true">
+        <form id="need-ride" name="needRide" action="{{ api }}/rider" method="post" class="ride-form" aria-hidden="true">
             <input type="hidden" name="_redirect" class="redirect" value="http://carpoolvote.com/thanks-rider" />
             <div class="bannerbox">
                 <h2 class="bannerbox__title">I need a ride</h2>
@@ -192,7 +192,7 @@ permalink: /
             </div>
         </form>
 
-        <form id="offer-ride" name="offerRide" action="{{ site.api }}/driver" method="post" class="ride-form" aria-hidden="true">
+        <form id="offer-ride" name="offerRide" action="{{ api }}/driver" method="post" class="ride-form" aria-hidden="true">
             <input type="hidden" name="_redirect" class="redirect" value="http://carpoolvote.com/thanks-driver" />
             <div class="bannerbox">
                 <h2 class="bannerbox__title">I can offer a ride</h2>
@@ -380,7 +380,7 @@ permalink: /
                     </div>
                     <p>Please also sign up to join the campaign! We’re supported entirely by a network of volunteers who believe passionately that democracy is for everybody.</p>
                     <p>We have a variety of roles for people with any amount of time to give. This could involve joining our volunteer pool who take on small tasks that help the project take big leaps forward. If you're a web developer, then consider contributing to our website on <a href="https://github.com/voteamerica/" target="_blank">GitHub</a>. We also have several strategic roles for those who want to remain actively involved until Election Day.</p>
-                    <form name="offerHelp" action="{{ site.api }}/helper" method="post" data-toggle="validator">
+                    <form name="offerHelp" action="{{ api }}/helper" method="post" data-toggle="validator">
                         <input type="hidden" name="_redirect" class="redirect" value="http://carpoolvote.com" />
 
                         <div class="form-group">


### PR DESCRIPTION
# Description
Use [GitHub meta data](https://help.github.com/articles/repository-metadata-on-github-pages) conditional to change api variable value on staging repo. So on the [main website](http://carpoolvote.com) the API url will be https://api.carpoolvote.com/live, but on the [staging site](richardwestenra.com/voteamerica.github.io) will be https://api.carpoolvote.com/test.

# Notes
This adds yet more extra empty lines to the start of the HTML source, but I don't think it matters. We can add a Jekyll plugin to compress HTML later maybe?