### PR TITLE
Indicate to rider/driver when backend has rejected request

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -85,6 +85,11 @@
         <script src="https://cdnjs.cloudflare.com/ajax/libs/1000hz-bootstrap-validator/0.11.5/validator.min.js"></script>
         <script> var remoteUrl = '{{ api }}'; </script>
         <script src="{{ baseurl }}scripts/selfservice.js"></script>
+    {% elsif page.thanks %}
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/1000hz-bootstrap-validator/0.11.5/validator.min.js"></script>
+        <script> var remoteUrl = '{{ api }}'; </script>
+        <script src="{{ baseurl }}scripts/thanks.js"></script>
     {% endif %}
 
     <script>

--- a/pages/thanks-driver.html
+++ b/pages/thanks-driver.html
@@ -44,5 +44,4 @@ thanks: true
             </div>
         </div>
     </div>
-    <!--<script src="/scripts/thanks.js"></script>-->
 </main>

--- a/pages/thanks-driver.html
+++ b/pages/thanks-driver.html
@@ -2,6 +2,7 @@
 layout: default
 permalink: thanks-driver/
 title: Thank you!
+thanks: true
 ---
 
 <main class="content">
@@ -43,5 +44,5 @@ title: Thank you!
             </div>
         </div>
     </div>
-    <script src="/scripts/thanks.js"></script>
+    <!--<script src="/scripts/thanks.js"></script>-->
 </main>

--- a/pages/thanks-driver.html
+++ b/pages/thanks-driver.html
@@ -8,18 +8,30 @@ title: Thank you!
     <div class="wrapper single-column offset-top">
         <div class="bannerbox">
             <div class="bannerbox__content">
-                <h1>Thank you</h1>
-                <p>for offering a fellow American a ride to claim their vote! Together, our driving volunteers could help shape the outcome of this election.</p>
-                <p>We've sent you a message confirming that we've received your offer.</p>
-                <p>Your driver offer reference number is: <b class="uuid">ID not loaded, please try again</b>.</p>
-                <p>Please <strong>keep this reference</strong> in case you need to manage your ride request.</p>
-                <p>To view or manage your matches, visit our <b><a class="self-service-url" href="../self-service/?type=driver">self-service portal</a></b>.</p>
+                <h1 id="thanks-header">Thank you</h1>
+                <span id="sorryHeading" hidden style="display:none">We are sorry</span>
 
-                <h2>What happens next?</h2>
-                <p>Our system will match you with a passenger(s), based on the information you've provided. We'll send you a notification of every ride request that matches your criteria. You can then accept as many ride requests as work for you.</p>
-                <p>Once you have accepted a ride request, we'll send you a message with the rider's contact details. It's then up the you and the rider to arrange when and where you'd like to meet, and any other details of your trip.</p>
+                <p id="introPara">for offering a fellow American a ride to claim their vote! Together, our driving volunteers could help shape the outcome of this election.</p>
+                <span id="sorryPara" hidden style="display:none">It has not been possible to process your request. Please see the information below for more details. We want to help you to volunteer, so please contact our phone support if you cannot resolve this issue yourself.</span>
 
-                <p>Let your friends know!</p>
+                <div id="responseDetails" hidden style="display:none">
+                    <p>Response code: <b id="responseCode" class="uuid"></b></p>                    
+                    <p>Response info: <b id="responseText" class="uuid"></b></p>                    
+                </div>
+                
+                <div id="requestSuccessInfo">
+                    <p>We've sent you a message confirming that we've received your offer.</p>
+                    <p>Your driver offer reference number is: <b class="uuid">ID not loaded, please try again</b>.</p>
+                    <p>Please <strong>keep this reference</strong> in case you need to manage your ride request.</p>
+                    <p>To view or manage your matches, visit our <b><a class="self-service-url" href="../self-service/?type=driver">self-service portal</a></b>.</p>
+
+                    <h2>What happens next?</h2>
+                    <p>Our system will match you with a passenger(s), based on the information you've provided. We'll send you a notification of every ride request that matches your criteria. You can then accept as many ride requests as work for you.</p>
+                    <p>Once you have accepted a ride request, we'll send you a message with the rider's contact details. It's then up the you and the rider to arrange when and where you'd like to meet, and any other details of your trip.</p>
+
+                    <p>Let your friends know!</p>
+                </div>
+
                 <ul class="social">
                     <li role="presentation" class="social__twitter">
                         <a href="https://twitter.com/intent/tweet" class="twitter-mention-button" data-text="I've signed up to offer a ride to a fellow American on @CarpoolVote. #Election2016 will be close. #CountEveryVote" data-related="" data-url="http://carpoolvote.com" data-show-count="false">Tweet to help others find out about this!</a>
@@ -31,4 +43,5 @@ title: Thank you!
             </div>
         </div>
     </div>
+    <script src="/scripts/thanks.js"></script>
 </main>

--- a/pages/thanks-rider.html
+++ b/pages/thanks-rider.html
@@ -8,17 +8,28 @@ title: Thank you!
     <div class="wrapper single-column offset-top">
         <div class="bannerbox">
             <div class="bannerbox__content">
-                <h1>Congratulations</h1>
-                <p>on taking this step to claim your vote! We’ve sent you a message confirming that we’ve received your request.</p>
-                <p>Your ride request reference number is: <b class="uuid">ID not loaded, please try again</b>.</p>
-                <p>Please <strong>keep this reference</strong> in case you need to manage your ride request.</p>
-                <p>To view or manage your ride request, visit our <b><a class="self-service-url" href="../self-service/?type=rider">self-service portal</a></b>.</p>
+                <h1 id="thanks-header">Congratulations</h1>
+                <span id="sorryHeading" hidden style="display:none">We are sorry</span>
+                
+                <p id="introPara">on taking this step to claim your vote! We’ve sent you a message confirming that we’ve received your request.</p>
+                <span id="sorryPara" hidden style="display:none">It has not been possible to process your request. Please see the information below for more details. We want to help you, so please contact our phone support if you cannot resolve this issue yourself.</span>
 
-                <h2>What happens next?</h2>
-                <p>Our system will match you with potential drivers, based on the information you’ve provided. We'll let you know as soon as a driver has accepted your request.</p>
-                <p>The driver will then get in touch with you through the preferred method of contact you specified on the form. It's then up the you and the driver to arrange when and where you'd like to meet, and any other details of your trip.</p>
+                <div id="responseDetails" hidden style="display:none">
+                    <p>Response code: <b id="responseCode" class="uuid"></b></p>                    
+                    <p>Response info: <b id="responseText" class="uuid"></b></p>                    
+                </div>
+                
+                <div id="requestSuccessInfo">
+                    <p>Your ride request reference number is: <b class="uuid">ID not loaded, please try again</b>.</p>
+                    <p>Please <strong>keep this reference</strong> in case you need to manage your ride request.</p>
+                    <p>To view or manage your ride request, visit our <b><a class="self-service-url" href="../self-service/?type=rider">self-service portal</a></b>.</p>
 
-                <p>Let your friends know!</p>
+                    <h2>What happens next?</h2>
+                    <p>Our system will match you with potential drivers, based on the information you’ve provided. We'll let you know as soon as a driver has accepted your request.</p>
+                    <p>The driver will then get in touch with you through the preferred method of contact you specified on the form. It's then up the you and the driver to arrange when and where you'd like to meet, and any other details of your trip.</p>
+                    <p>Let your friends know!</p>
+                </div>
+
                 <ul class="social">
                     <li role="presentation" class="social__twitter">
                         <a href="https://twitter.com/intent/tweet" class="twitter-mention-button" data-text="I’ve signed up for a ride to #ClaimMyVote on @CarpoolVote. #Election2016 will be close. #CountEveryVote" data-related="" data-url="http://carpoolvote.com" data-show-count="false">Tweet to help others find out about this!</a>
@@ -30,4 +41,5 @@ title: Thank you!
             </div>
         </div>
     </div>
+    <script src="/scripts/thanks.js"></script>
 </main>

--- a/pages/thanks-rider.html
+++ b/pages/thanks-rider.html
@@ -42,5 +42,4 @@ thanks: true
             </div>
         </div>
     </div>
-    <!--<script src="/scripts/thanks.js"></script>-->
 </main>

--- a/pages/thanks-rider.html
+++ b/pages/thanks-rider.html
@@ -2,6 +2,7 @@
 layout: default
 permalink: thanks-rider/
 title: Thank you!
+thanks: true
 ---
 
 <main class="content">
@@ -41,5 +42,5 @@ title: Thank you!
             </div>
         </div>
     </div>
-    <script src="/scripts/thanks.js"></script>
+    <!--<script src="/scripts/thanks.js"></script>-->
 </main>

--- a/scripts/thanks.js
+++ b/scripts/thanks.js
@@ -1,0 +1,33 @@
+if (!remoteUrl) {
+  var remoteUrl = "https://api.carpoolvote.com/live";
+}
+
+const handleBackendResponse = () => {
+  var data = tinyQuery.getAll();
+
+  var heading             = document.getElementById("thanks-header");
+  var introPara           = document.getElementById("introPara");
+  var successInfo         = document.getElementById("requestSuccessInfo");
+  var responseDetails     = document.getElementById("responseDetails");
+  var responseCode        = document.getElementById("responseCode");
+  var responseText        = document.getElementById("responseText");
+
+  var headingFailureText  = document.getElementById("sorryHeading").innerHTML;
+  var paraFailureText     = document.getElementById("sorryPara").innerHTML;
+
+  if (data.code != "0") {
+    heading.innerHTML   = headingFailureText;
+    introPara.innerHTML = paraFailureText;
+
+    successInfo.setAttribute("hidden", "hidden");
+    successInfo.setAttribute("style", "display:none");    
+
+    responseDetails.removeAttribute("hidden");
+    responseDetails.setAttribute("style", "");    
+
+    responseCode.innerHTML = data.code;
+    responseText.innerHTML = data.info;
+  }
+} 
+
+window.onload = handleBackendResponse; 

--- a/scripts/thanks.js
+++ b/scripts/thanks.js
@@ -1,33 +1,25 @@
+var data = tinyQuery.getAll();
 
-// var data = tinyQuery.getAll();
+var heading             = document.getElementById("thanks-header");
+var introPara           = document.getElementById("introPara");
+var successInfo         = document.getElementById("requestSuccessInfo");
+var responseDetails     = document.getElementById("responseDetails");
+var responseCode        = document.getElementById("responseCode");
+var responseText        = document.getElementById("responseText");
 
+var headingFailureText  = document.getElementById("sorryHeading").innerHTML;
+var paraFailureText     = document.getElementById("sorryPara").innerHTML;
 
-// const handleBackendResponse = () => {
-  var data = tinyQuery.getAll();
+if (data.code != "0") {
+  heading.innerHTML   = headingFailureText;
+  introPara.innerHTML = paraFailureText;
 
-  var heading             = document.getElementById("thanks-header");
-  var introPara           = document.getElementById("introPara");
-  var successInfo         = document.getElementById("requestSuccessInfo");
-  var responseDetails     = document.getElementById("responseDetails");
-  var responseCode        = document.getElementById("responseCode");
-  var responseText        = document.getElementById("responseText");
+  successInfo.setAttribute("hidden", "hidden");
+  successInfo.setAttribute("style", "display:none");    
 
-  var headingFailureText  = document.getElementById("sorryHeading").innerHTML;
-  var paraFailureText     = document.getElementById("sorryPara").innerHTML;
+  responseDetails.removeAttribute("hidden");
+  responseDetails.setAttribute("style", "");    
 
-  if (data.code != "0") {
-    heading.innerHTML   = headingFailureText;
-    introPara.innerHTML = paraFailureText;
-
-    successInfo.setAttribute("hidden", "hidden");
-    successInfo.setAttribute("style", "display:none");    
-
-    responseDetails.removeAttribute("hidden");
-    responseDetails.setAttribute("style", "");    
-
-    responseCode.innerHTML = data.code;
-    responseText.innerHTML = data.info;
-  }
-// } 
-
-// window.onload = handleBackendResponse; 
+  responseCode.innerHTML = data.code;
+  responseText.innerHTML = data.info;
+}

--- a/scripts/thanks.js
+++ b/scripts/thanks.js
@@ -1,8 +1,8 @@
-if (!remoteUrl) {
-  var remoteUrl = "https://api.carpoolvote.com/live";
-}
 
-const handleBackendResponse = () => {
+// var data = tinyQuery.getAll();
+
+
+// const handleBackendResponse = () => {
   var data = tinyQuery.getAll();
 
   var heading             = document.getElementById("thanks-header");
@@ -28,6 +28,6 @@ const handleBackendResponse = () => {
     responseCode.innerHTML = data.code;
     responseText.innerHTML = data.info;
   }
-} 
+// } 
 
-window.onload = handleBackendResponse; 
+// window.onload = handleBackendResponse; 


### PR DESCRIPTION
@richardwestenra the backend can now reject requests (e.g. zip code, date) and returns a relevant status code and text. 

This PR shows/hides the relevant info as necessary. The header and first para are adjusted if necessary.

EDIT: currently the site congratulates a rider/driver who has in fact had their input rejected by the db (there is no db entry at all for this user). This is misleading for the user and unhelpful for the phone support team. This PR gives clear indication of the problem to the user. 

Some notes:
1) the backend to test against may not yet be deployed. EDIT: deployed now

2) There is already a css style for `display:none` in the main css file, so I've hard-coded it here to avoid either adding a duplicate style to the css file, or relying on a style that may be refactored later.

3) use of `hidden` and `display:none` is based on guidelines from an well-regarded accessibility agency. This works with older browsers and screen readers

4) I couldn't seem to get the jekyll settings for selectively adding the script for the thanks pages, so added a script element directly EDIT: done, thanks for the tip