### PR TITLE
Thanks redirect

### DIFF
--- a/_config-dev.yml
+++ b/_config-dev.yml
@@ -1,2 +1,2 @@
 api: "https://api.carpoolvote.com/test"
-cp_site: "http://carpoolvote.com"
+cp_site: "http://richardwestenra.com/voteamerica.github.io"

--- a/_config-dev.yml
+++ b/_config-dev.yml
@@ -1,1 +1,2 @@
 api: "https://api.carpoolvote.com/test"
+cp_site: "http://carpoolvote.com"

--- a/_config-local.yml
+++ b/_config-local.yml
@@ -1,0 +1,2 @@
+api: "http://localhost:8000"
+cp_site: "http://localhost:4000"

--- a/_config.yml
+++ b/_config.yml
@@ -8,3 +8,4 @@ permalink: :title/
 relative_permalinks: false
 
 api: "https://api.carpoolvote.com/live"
+cp_site: "http://carpoolvote.com"

--- a/_includes/cp_site.html
+++ b/_includes/cp_site.html
@@ -1,0 +1,4 @@
+{% comment %}
+	Change the carpool site url to the test value on the test repo
+{% endcomment %}
+{% assign cp_site = site.cp_site %}

--- a/_includes/cp_site.html
+++ b/_includes/cp_site.html
@@ -1,4 +1,7 @@
 {% comment %}
-	Change the carpool site url to the test value on the test repo
+	Change the carpool site url to the value defined in the relevant config file
 {% endcomment %}
 {% assign cp_site = site.cp_site %}
+{% if site.github.owner_name == 'richardwestenra' %}
+	{% assign cp_site = 'http://richardwestenra.com/voteamerica.github.io' %}
+{% endif %}

--- a/pages/index.html
+++ b/pages/index.html
@@ -7,6 +7,7 @@ permalink: /
 ---
 
 {% include api.html %}
+{% include cp_site.html %}
 
 <noscript>
     <style>
@@ -52,7 +53,7 @@ permalink: /
 
     <div id="forms" class="forms wrapper offset-top">
         <form id="need-ride" name="needRide" action="{{ api }}/rider" method="post" class="ride-form" aria-hidden="true">
-            <input type="hidden" name="_redirect" class="redirect" value="http://carpoolvote.com/thanks-rider/?type=rider" />
+            <input type="hidden" name="_redirect" class="redirect" value="{{ cp_site }}/thanks-rider/?type=rider" />
             <div class="bannerbox">
                 <h2 class="bannerbox__title">I need a ride</h2>
                 <div class="bannerbox__content">

--- a/pages/index.html
+++ b/pages/index.html
@@ -195,7 +195,7 @@ permalink: /
         </form>
 
         <form id="offer-ride" name="offerRide" action="{{ api }}/driver" method="post" class="ride-form" aria-hidden="true">
-            <input type="hidden" name="_redirect" class="redirect" value="http://carpoolvote.com/thanks-driver/?type=driver" />
+            <input type="hidden" name="_redirect" class="redirect" value="{{ cp_site }}/thanks-driver/?type=driver" />
             <div class="bannerbox">
                 <h2 class="bannerbox__title">I can offer a ride</h2>
                 <div class="bannerbox__content">


### PR DESCRIPTION
@richardwestenra this corrects existing behaviour to redirect the user to the thanks page on the correct site (live, test, local)

Two new files: 
1) cp_site.html - provides a jekyll template var for the redirect site
2) _config_local.yml - this supports local/docker setups in addition to the existing live/test setups

Tested on local, test and live environments

Fixes https://github.com/voteamerica/voteamerica.github.io/issues/273
Fixes https://github.com/voteamerica/backend/issues/106
Fixes https://github.com/voteamerica/backend/issues/110