### PR TITLE
Change the og:image from the logo to the road photo

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="{% if page.title %}{{page.title}} | {% endif %}{{site.name}}" />
     <meta property="og:description" content="{% if page.description %}{{page.description}}{% else %}{{site.description}}{% endif %}"/>
-    <meta property="og:image" content="http://carpoolvote.com/images/logo.png" />
+    <meta property="og:image" content="http://carpoolvote.com/images/road.jpg" />
 
     <link rel="icon" href="favicon.ico">
     <link href='https://fonts.googleapis.com/css?family=Lato:400,300,700' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
Facebook isn't accepting [the logo](http://carpoolvote.com/images/logo.png) as a valid image, so use [the road](http://carpoolvote.com/images/road.jpg) instead:
![image](https://cloud.githubusercontent.com/assets/1155816/25793308/b9de528a-33c3-11e7-91df-9d15c2fad02a.png)