### PR TITLE
prevent signup without opening tos

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -172,7 +172,7 @@ permalink: /
 
                     <div class="form-group checkbox">
                         <label for="RiderAgreeTnC">
-                            <input type="checkbox" id="RiderAgreeTnC" name="RiderAgreeTnC" required /> I agree to the <a href="terms-conditions/" target="_blank">Terms &amp; Conditions</a>.
+                            <input type="checkbox" id="RiderAgreeTnC" name="RiderAgreeTnC" required disabled /> I agree to the <a href="terms-conditions/" id="RiderAgreeTnCLink" target="_blank">Terms &amp; Conditions</a>. <strong>Note: you must first open the Terms &amp; Conditions page before agreeing. You may not sign up without agreeing to the Terms &amp; Conditions.</strong>
                         </label>
                         <small>I understand that Carpool Vote LLC will share my contact details with the driver if there's a match. (Carpool Vote LLC will not share personal details with anybody else, unless required by law, and will destroy them within three months of election day of you've asked us not to stay in touch.)</small>
                         <small>I understand that Carpool Vote LLC provides introductions between riders and volunteer drivers who have signed up on the platform. I understand that anybody can sign up to drive and Carpool Vote LLC is unable to perform any background checks on people who use the platform. As with any other environment where I meet new people, I will take steps to keep myself and my possessions safe and accept that Carpool Vote LLC cannot be responsible if anything goes wrong.</small>
@@ -286,7 +286,7 @@ permalink: /
 
                     <div class="form-group checkbox">
                         <label for="DriverAgreeTnC">
-                            <input type="checkbox" id="DriverAgreeTnC" name="DriverAgreeTnC" required /> I agree to the <a href="terms-conditions/" target="_blank">Terms &amp; Conditions</a>
+                            <input type="checkbox" id="DriverAgreeTnC" name="DriverAgreeTnC" required disabled /> I agree to the <a href="terms-conditions/" id="DriverAgreeTnCLink" target="_blank">Terms &amp; Conditions</a>. <strong>Note: you must first open the Terms &amp; Conditions page before agreeing. You may not sign up without agreeing to the Terms &amp; Conditions.</strong>
                         </label>
                         <small>I understand that Carpool Vote LCC will share my contact details with the driver if there's a match. (Carpool Vote LLC will not share personal details with anybody else, unless required by law, and will destroy them within three months of election day of you've asked us not to stay in touch.)</small>
                         <small>I understand that Carpool Vote LLC provides introductions between riders and volunteer drivers who have signed up on the platform. I understand that anybody can sign up to drive and Carpool Vote LLC is unable to perform any background checks on people who use the platform. As with any other environment where I meet new people, I will take steps to keep myself and my possessions safe and accept that Carpool Vote LLC cannot be responsible if anything goes wrong.</small>

--- a/scripts/home.js
+++ b/scripts/home.js
@@ -198,6 +198,19 @@ $(function(){
             // to prevent a recursive trigger loop
             $(sibling).trigger('input');
         });
+
+	// Require the user to have opened the Terms and Conditions link by
+	// removing the default `disable` attribute of the input element
+	// when the link has been clicked
+
+	// Apply this logic to both the rider signup and driver signup
+	$('#RiderAgreeTnCLink').click(function() {
+	    $('#RiderAgreeTnC').removeAttr('disabled');
+	});
+
+	$('#DriverAgreeTnCLink').click(function() {
+	    $('#DriverAgreeTnC').removeAttr('disabled');
+	});
     }
 
     /**


### PR DESCRIPTION
this PR resolves the subtask from Issue #267 

- [x]  On both signup forms, force user to open terms and conditions before checking the box stating that they agree.

by making the following changes:

1. by default, disable the 'accept tos' checkbox
    - but the input is still `required`, so the form cannot be submitted without it (see below)
2. when the tos link has been opened, remove the `disabled` attribute from the checkbox input

this is one solution to an open ended problem. i also considered forcing the user to always open the tos by opening the link when the 'accept tos' checkbox was clicked, but i thought this would result in bad UX. 

the downside to this solution is that the form validation library appears to ignore the 'accept tos' input when it is disabled and the form is submitted (erroneously). whereas other `div.form-group` elements will receive `has-error has-danger` when their input is invalid on submission, the 'accept tos' parent div does not receive these classes. (try submitting a blank form in this PR to understand what i mean). this could be resolved by adding the `has-error has-danger` classes by default, and then removing them dynamically when the terms and conditions link has been opened. open to suggestions!