### PR TITLE
hide election clock asap

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -332,7 +332,7 @@ permalink: /
           <div class="bannerbox" id="story">
                 <h2 class="bannerbox__title">Our Story</h2>
                 <div class="bannerbox__content">
-                    <p>In many states, new voting rules have made it more difficult for people to get to polling stations. These rules particularly affect people of color, people with disabilities, young people, elderly people, and women. Carpool Vote is a tool to fight back against an unfair political system in the 2016 election.</p>
+                    <p>In many states, new voting rules have made it more difficult for people to get to polling stations. These rules particularly affect people of color, people with disabilities, young people, elderly people, and women. Carpool Vote is a tool to fight back against an unfair political system in the 2017 elections and beyond.</p>
 
                     <p>We connect volunteer drivers with anybody who needs a ride - to the polls or voter I.D. office.</p>
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -359,7 +359,7 @@ permalink: /
                     </ul>
                 </div>
             </div>
-            <div class="bannerbox" id="countdown">
+            <div class="bannerbox" id="countdown" style="display: none;">
                 <h2 class="bannerbox__title">2016 Election Countdown Clock</h2>
                 <div class="bannerbox__content">
                     <iframe src="http://www.270towin.com/2016-countdown-clock/widget300x200.php" width="300" height="200" style="border:none; max-width:100%">


### PR DESCRIPTION
@richardwestenra PR created in response to ASAP request re countdown clock. We are getting some emails from people who'd like to use the system but the clock gives them a confusing message

Page looks fine to me without clock - no unequal length columns etc. YMMV

EDIT: have now also updated a reference to the 2016 election

UPDATE: may now be resolved by https://github.com/voteamerica/voteamerica.github.io/pull/289 (@geoffreyyip has been working on this as part of a larger PR)