### PR TITLE
move self service portal link to nav

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -9,9 +9,6 @@
                 {% endif %}
             </ul>
             <ul class="footer__links footer__links--right">
-                {% if page.url != '/self-service' %}
-                    <li><a href="{{ baseurl }}self-service/">Self-service portal</a></li>
-                {% endif %}
                 {% if page.url != '/terms-conditions' %}
                     <li><a href="{{ baseurl }}terms-conditions/">Terms &amp; conditions</a></li>
                 {% endif %}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -19,23 +19,29 @@
             <img id="logo" class="logo__img" src="{{ baseurl }}images/logo.png" alt="Carpool Vote" width=709 height=187 />
         </a>
 
-        <ul id="nav-links" class="nav__links">
+        <div class="nav__links">
+          <ul id="nav-links" class="nav__links_list">
             {% if page.navigation == 'full' %}
-                <li class="nav__item nav__story">
-                    <a href="{{ baseurl }}story/" class="nav__link story" id="story-link">Our story</a>
-                </li>
-                <li class="nav__item nav__how">
-                    <a href="{{ baseurl }}how-it-works/" class="nav__link">How it works</a>
-                </li>
-                <li class="nav__item nav__support">
-                    <a href="{{ baseurl }}#howtoclaim" class="nav__link scroll">Voting info</a>
-                </li>
+            <li class="nav__item nav__story">
+              <a href="{{ baseurl }}story/" class="nav__link story" id="story-link">Our story</a>
+            </li>
+            <li class="nav__item nav__how">
+              <a href="{{ baseurl }}how-it-works/" class="nav__link">How it works</a>
+            </li>
+            <li class="nav__item nav__support">
+              <a href="{{ baseurl }}#howtoclaim" class="nav__link scroll">Voting info</a>
+            </li>
             {% else %}
-                <li class="nav__item nav__story">
-                    <a href="{{ baseurl }}" class="nav__link" id="home-link">Back to Home</a>
-                </li>
+            <li class="nav__item nav__support">
+              <a href="{{ baseurl }}" class="nav__link" id="home-link">Back to Home</a>
+            </li>
             {% endif %}
-        </ul>
+          </ul>
+
+          {% if page.url != '/self-service/' %}
+          <a class="nav__link" href="{{ baseurl }}self-service/">My Rides</a>
+          {% endif %}
+        </div>
 
         <ul class="social">
             <li role="presentation" class="social__twitter">

--- a/styles/main.css
+++ b/styles/main.css
@@ -271,6 +271,12 @@ a.twitter-mention-button {
     text-align: center;
 }
 
+.nav__links_list {
+    margin-top: 0;
+    margin-bot: 5px;
+    padding-left: 0;
+}
+
 .nav__item {
     display: inline;
     border-right: solid 1px #297bbb;


### PR DESCRIPTION
## Motivation

Resolves Issue #292 

## Changes

- [x] fix bug where self service portal link was unintentionally always displayed
  - comparison string was missing `/`
- [x] fix ui bug where "back to home" nav link would display a post-separator
  - note the `|` character next to "Back to Home" at http://carpoolvote.com/self-service/
- [x] move self service portal link to header, optimize for all screen sizes

## Screenshots

![my_rides_phone](https://cloud.githubusercontent.com/assets/17035732/26682491/9ec81474-46ae-11e7-99c8-bf52cce2a779.png)

![my_rides_tablet](https://cloud.githubusercontent.com/assets/17035732/26682496/a221b3fa-46ae-11e7-8042-88cd2846a2ea.png)
![my_rides_laptop](https://cloud.githubusercontent.com/assets/17035732/26682497/a4a02d00-46ae-11e7-9f80-6959bbbd3503.png)

