### PR TITLE
Fix North Carolina links in voting-details.json

### DIFF
--- a/scripts/voting-details.json
+++ b/scripts/voting-details.json
@@ -199,8 +199,8 @@
   },
   {
     "State": "NorthCarolina",
-    "RegCheck": "https://vt.ncsbe.gov/voter_search_public/",
-    "LocationFinder": "https://enr.ncsbe.gov/pollingplace_search/",
+    "RegCheck": "https://vt.ncsbe.gov/RegLkup/",
+    "LocationFinder": "https://vt.ncsbe.gov/PPLkup/",
     "Twitter": "https://twitter.com/ncsbe"
   },
   {


### PR DESCRIPTION
Fix broken links for NC voter registration and polling place lookups